### PR TITLE
support for multiple preFetch functions

### DIFF
--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -17,11 +17,16 @@ export default context => {
   // A preFetch hook dispatches a store action and returns a Promise,
   // which is resolved when the action is complete and store state has been
   // updated.
-  return Promise.all(router.getMatchedComponents().map(component => {
+  return Promise.all(router.getMatchedComponents().reduce((accu, component) => {
     if (component.preFetch) {
-      return component.preFetch(store)
+      return accu.concat(
+        [].concat(component.preFetch).map(function(preFetch) {
+          return preFetch.call(preFetch, store)
+        }.bind(component))
+      );
     }
-  })).then(() => {
+    return accu;
+  }, [])).then(() => {
     isDev && console.log(`data pre-fetch: ${Date.now() - s}ms`)
     // After all preFetch hooks are resolved, our store is now
     // filled with the state needed to render the app.


### PR DESCRIPTION
<del>
seems that following preFetch function wil cause error:

```javascript
function (store) {
   return Prmose.all(store.dispatch('ACTION_1'), store.dispatch('ACTION_2'))
}
```
</del>

however, an array of function is not supported yet. 

just a littile change,  and we will be able to use mutiple preFetch functions:

``` javascript
preFetch: [fetchA, fetchB],
```
