### PR TITLE
Add memory-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.14.0",
     "firebase": "^2.4.2",
     "lru-cache": "^4.0.1",
+    "memory-fs": "^0.3.0",
     "serialize-javascript": "^1.3.0",
     "serve-favicon": "^2.3.0",
     "vue": "^2.0.0-rc.1",


### PR DESCRIPTION
An error occurred while I was running it in windows.
```bash
Error: Cannot find module 'memory-fs'
```
I added a dependencies `memory-fs`