### PR TITLE
Use `$duration` consistently in Spinner styling

### DIFF
--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -39,7 +39,7 @@ $duration = 1.4s
   stroke-dasharray $offset
   stroke-dashoffset 0
   transform-origin center
-  animation dash 1.4s ease-in-out infinite
+  animation dash $duration ease-in-out infinite
 
 @keyframes dash
   0%


### PR DESCRIPTION
The literal value `1.4s` was used, but the existing variable `$duration` was already supposed to abstract that value.