### PR TITLE
server-side-rendering error handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -59,10 +59,9 @@ app.get('*', (req, res) => {
   const renderStream = renderer.renderToStream(context)
   let firstChunk = true
 
-  res.write(html.head)
-
   renderStream.on('data', chunk => {
     if (firstChunk) {
+      res.write(html.head)
       // embed initial store state
       if (context.initialState) {
         res.write(
@@ -82,7 +81,9 @@ app.get('*', (req, res) => {
   })
 
   renderStream.on('error', err => {
-    throw err
+    // Render Error Page or Redirect
+    res.status(500).end('Internal Error 500')
+    console.error(`error during render : ${req.url}`)
   })
 })
 


### PR DESCRIPTION
express should not be crushed
even if server-side-rendering occurs an error.