### PR TITLE
Use gzip compression for static assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:server": "cross-env NODE_ENV=production webpack --config build/webpack.server.config.js --progress --hide-modules"
   },
   "dependencies": {
+    "compression": "^1.6.2",
     "es6-promise": "^3.2.1",
     "express": "^4.14.0",
     "firebase": "^2.4.2",

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const resolve = file => path.resolve(__dirname, file)
 const express = require('express')
 const favicon = require('serve-favicon')
 const serialize = require('serialize-javascript')
+const compression = require('compression')
 
 // https://github.com/vuejs/vue/blob/next/packages/vue-server-renderer/README.md#why-use-bundlerenderer
 const createBundleRenderer = require('vue-server-renderer').createBundleRenderer
@@ -46,6 +47,7 @@ function createRenderer (bundle) {
   })
 }
 
+app.use(compression({threshold: 0}))
 app.use('/dist', express.static(resolve('./dist')))
 app.use(favicon(resolve('./src/assets/logo.png')))
 


### PR DESCRIPTION
I noticed that the static JS/CSS assets weren't gzipped. Adding Express [compression middleware](https://www.npmjs.com/package/compression) fixes this (while intelligently skipping the HTML since that's chunked and needs to be streamed).

Here's the "before" on a Nexus 5 throttled to 3G; notice the large JS download time:

![screenshot 2016-10-23 12 47 48](https://cloud.githubusercontent.com/assets/283842/19630145/ff6e821e-9938-11e6-95dc-61f18d77553d.png)

And here's the "after":

![screenshot 2016-10-23 15 49 43](https://cloud.githubusercontent.com/assets/283842/19630147/053b20da-9939-11e6-8a14-14f7e34a1f51.png)

Great work on Vue! Really love the balance between DX and UX; I wrote a bit about it [on Twitter](https://twitter.com/nolanlawson/status/790268498639327232). :smiley: