### PR TITLE
Allow root App component to have its own preFetch

### DIFF
--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -1,4 +1,5 @@
 import { app, router, store } from './app'
+import App from './App.vue'
 
 const isDev = process.env.NODE_ENV !== 'production'
 
@@ -17,7 +18,7 @@ export default context => {
   // A preFetch hook dispatches a store action and returns a Promise,
   // which is resolved when the action is complete and store state has been
   // updated.
-  return Promise.all(router.getMatchedComponents().map(component => {
+  return Promise.all(router.getMatchedComponents().concat([App]).map(component => {
     if (component.preFetch) {
       return component.preFetch(store)
     }


### PR DESCRIPTION
Sometimes the App requires global preFetch. An example of that could be the case when you have an external admin panel, providing edit interface for some amount of variables, and a single api method, returning a whole snapshot of this data. In this case the whole frontend app requires just a single prefetch, which is not to be placed in any particular route-dependent component, but rather to be done somehow globally.