### PR TITLE
Fixes -- block-scoped declarations not available outside strict mode

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+"use strict"
+
 process.env.VUE_ENV = 'server'
 const isProd = process.env.NODE_ENV === 'production'
 


### PR DESCRIPTION
> node server

vue-hackernews-2.0/server.js:14
let indexHTML // generated by html-webpack-plugin
^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:387:25)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:146:18)
    at node.js:404:3