### PR TITLE
add hash to server-initialized state

### DIFF
--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -1,6 +1,8 @@
 import 'es6-promise/auto'
 import { app, store } from './app'
 
+// put a patch on server-initialized state for hash which is only available to the browser
+window.__INITIAL_STATE__.route.hash = window.location.hash
 // prime the store with server-initialized state.
 // the state is determined during SSR and inlined in the page markup.
 store.replaceState(window.__INITIAL_STATE__)


### PR DESCRIPTION
hash is only available to the browser. Should put a patch for it or the # fragments will be lost (example : `http://localhost:8080/top#app` will return `http://localhost:8080/top`)
, which is important for anchor tags to jump to specific location on a page

