### PR TITLE
Keep App component isolated from Root component

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -20,7 +20,7 @@ Object.keys(filters).forEach(key => {
 const app = new Vue({
   router,
   store,
-  ...App
+  render: h => h(App)
 })
 
 // expose the app, the router and the store.


### PR DESCRIPTION
This will fix the Webpack hot-reload `"Root or manually mounted instance modified. Full reload required."` warning that gets thrown when you update `App.vue`.