### PR TITLE
make vendor really cached. Do not change hash.

### DIFF
--- a/build/webpack.client.config.js
+++ b/build/webpack.client.config.js
@@ -19,7 +19,7 @@ const config = merge(base, {
     }),
     // extract vendor chunks for better caching
     new webpack.optimize.CommonsChunkPlugin({
-      name: 'vendor'
+      name: ['vendor', 'manifest']
     }),
     // generate output HTML
     new HTMLPlugin({


### PR DESCRIPTION
make vendor really cached. Do not change hash every time.
[Reference](https://webpack.js.org/guides/code-splitting-libraries/#implicit-common-vendor-chunk)