### PR TITLE
check if item exists before checking if children exist

### DIFF
--- a/src/views/ItemView.vue
+++ b/src/views/ItemView.vue
@@ -39,7 +39,7 @@ function fetchItem (store) {
 
 // recursively fetch all descendent comments
 function fetchComments (store, item) {
-  if (item.kids) {
+  if (item && item.kids) {
     return store.dispatch('FETCH_ITEMS', {
       ids: item.kids
     }).then(() => Promise.all(item.kids.map(id => {


### PR DESCRIPTION
I've noticed that when fetching comments recursively the hackernews firebase api returns items that may be undefined, even if their id exists. When this happens an error is thrown because technically no item matches that id. This leaves the ItemView in a loading state and no comments are shown. Checking if the item exists before should fix this error from being thrown. 