### PR TITLE
fix: `express.static()` accepts `maxAge` option in milliseconds rather than in seconds

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,7 +55,7 @@ if (isProd) {
 }
 
 const serve = (path, cache) => express.static(resolve(path), {
-  maxAge: cache && isProd ? 60 * 60 * 24 * 30 : 0
+  maxAge: cache && isProd ? 1000 * 60 * 60 * 24 * 30 : 0
 })
 
 app.use(compression({ threshold: 0 }))


### PR DESCRIPTION
FYI: http://expressjs.com/en/4x/api.html#express.static