### PR TITLE
Fix fetching for items with no comments

### DIFF
--- a/src/views/ItemView.vue
+++ b/src/views/ItemView.vue
@@ -68,6 +68,10 @@ export default {
 
   methods: {
     fetchComments () {
+      if (!this.item.kids) {
+        this.loading = false
+        return
+      }
       this.loading = true
       fetchComments(this.$store, this.item).then(() => {
         this.loading = false


### PR DESCRIPTION
There is an error in fetching items with no comments, because it's supposed to return a promise from function fetchComments. However, if the item doesn't match the condition, the function will not return it. This leaves the ItemView in a loading state and an error appear. 
Checking if the item has kids should fix this error from being thrown.
