### PR TITLE
Stop spinner for item hasn't comment

### DIFF
--- a/src/views/ItemView.vue
+++ b/src/views/ItemView.vue
@@ -69,6 +69,7 @@ export default {
   methods: {
     fetchComments () {
       if (!this.item || !this.item.kids) {
+        this.loading = false
         return
       }
 


### PR DESCRIPTION
Issue:
  Open the ItemView which that Item hasn't any comment, the spinner will
be there all the time.

How to fix:
  Set the loading to false if there is no comment.