### PR TITLE
Explicitly enable Vue devtools for better reviewability

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,9 @@ import { sync } from 'vuex-router-sync'
 import titleMixin from './util/title'
 import * as filters from './util/filters'
 
+// explicitly enable Vue dev-tools
+Vue.config.devtools = true
+
 // mixin for handling title
 Vue.mixin(titleMixin)
 


### PR DESCRIPTION
This is a Vue app example, so it should have Dev Tools enabled for anyone who wants to fiddle around with things.