### PR TITLE
fix recursive calling api while fetching comments

### DIFF
--- a/src/views/ItemView.vue
+++ b/src/views/ItemView.vue
@@ -63,7 +63,9 @@ export default {
 
   // refetch comments if item changed
   watch: {
-    item: 'fetchComments'
+    item: function () {
+      !this.loading && this.fetchComments();
+    }
   },
 
   methods: {


### PR DESCRIPTION
When we get comment from api we do Vue.set(state.items, item.id, item). It triggers watcher and call api again. So we do not do call api while requests are happening.