### PR TITLE
remove redundant v-if

### DIFF
--- a/src/views/ItemView.vue
+++ b/src/views/ItemView.vue
@@ -1,29 +1,27 @@
 <template>
   <div class="item-view" v-if="item">
-    <template v-if="item">
-      <div class="item-view-header">
-        <a :href="item.url" target="_blank">
-          <h1>{{ item.title }}</h1>
-        </a>
-        <span v-if="item.url" class="host">
-          ({{ item.url | host }})
-        </span>
-        <p class="meta">
-          {{ item.score }} points
-          | by <router-link :to="'/user/' + item.by">{{ item.by }}</router-link>
-          {{ item.time | timeAgo }} ago
-        </p>
-      </div>
-      <div class="item-view-comments">
-        <p class="item-view-comments-header">
-          {{ item.kids ? item.descendants + ' comments' : 'No comments yet.' }}
-          <spinner :show="loading"></spinner>
-        </p>
-        <ul v-if="!loading" class="comment-children">
-          <comment v-for="id in item.kids" :key="id" :id="id"></comment>
-        </ul>
-      </div>
-    </template>
+    <div class="item-view-header">
+      <a :href="item.url" target="_blank">
+        <h1>{{ item.title }}</h1>
+      </a>
+      <span v-if="item.url" class="host">
+        ({{ item.url | host }})
+      </span>
+      <p class="meta">
+        {{ item.score }} points
+        | by <router-link :to="'/user/' + item.by">{{ item.by }}</router-link>
+        {{ item.time | timeAgo }} ago
+      </p>
+    </div>
+    <div class="item-view-comments">
+      <p class="item-view-comments-header">
+        {{ item.kids ? item.descendants + ' comments' : 'No comments yet.' }}
+        <spinner :show="loading"></spinner>
+      </p>
+      <ul v-if="!loading" class="comment-children">
+        <comment v-for="id in item.kids" :key="id" :id="id"></comment>
+      </ul>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
Did not see a reason to have duplicate `v-if="item"` directives on lines 2 and 3.
Checked the blame, which mentions adjusting spinner position, but the template tag should be unreachable if !item and transparent otherwise.