### PR TITLE
Fix: Removed loading icon when there are no comments

### DIFF
--- a/src/views/ItemView.vue
+++ b/src/views/ItemView.vue
@@ -69,7 +69,7 @@ export default {
   methods: {
     fetchComments () {
       if (!this.item || !this.item.kids) {
-        return
+        return this.loading = false
       }
 
       this.loading = true


### PR DESCRIPTION
Previous to this commit, if you view a thread which has zero comments, the loading property never gets set to false.

I'm not sure if the approach I used was correct, maybe you could guide me in the right direction if something about it smells.